### PR TITLE
Addition bidirectional hovercraft (water version Marine Days 2025)

### DIFF
--- a/ESP_Hover_Browser/ESP_Hover_Browser.ino
+++ b/ESP_Hover_Browser/ESP_Hover_Browser.ino
@@ -233,7 +233,7 @@ void updateMotors()
 #endif
     int doel_motorZsnelheid;
     int max_motorsnelheid = map(ui_slider2, 0, 360, PWM_RANGE / 2, PWM_RANGE);
-#if defined(USE_CONFIG_HOVERSERVO)
+#if defined(ZMOTOR_UP_ONLY)
     if (ui_joystick_y <= 0)
     {
       doel_motorZsnelheid = map(-ui_joystick_y, 0, 180, 0, max_motorsnelheid);
@@ -242,7 +242,7 @@ void updateMotors()
     {
       doel_motorZsnelheid = 0;
     }
-#elif defined (USE_CONFIG_HOVERSERVO_BIDI)
+#else
     doel_motorZsnelheid = map(-ui_joystick_y, 180, -180, -max_motorsnelheid, max_motorsnelheid);
 #endif
     if (gyroBeschikbaar && (abs(doel_motorZsnelheid) > 5)) // gyro
@@ -819,6 +819,7 @@ void loop()
 
   // delay(2);
 }
+
 
 
 

--- a/ESP_Hover_Browser/config.h
+++ b/ESP_Hover_Browser/config.h
@@ -11,6 +11,7 @@
 
 // #define ENV_HOVERSERVOGYRO_ESP8266_ESP01_LEDPIN2_V0
 // #define ENV_HOVERSERVOGYRO_ESP32C3_SUPERMINI_WS2812FX_V0
+// #define ENV_HOVERSERVOGYRO_ESP32C3_WROOM_V1
 
 // Als de defines in platformio.ini gedefinieerd zijn:
 // #define ENV_USER_DEFINED
@@ -22,7 +23,7 @@ Als je een ander board wenst te definiëren, zijn volgende defines nodig:
 - FASTIMU_TYPE
 - IMU_I2C_ADDRESS
 - GYRO_REGELING_P
-- GYRO_REGELING_MAX_DRAAI
+- GYRO_REGELING_MAX_DRAAI (optioneel default 1.0)
 - GYRO_REGELING_BIAS
 - GYRO_DIRECTION : GYRO_DIRECTION_X, GYRO_DIRECTION_Y of GYRO_DIRECTION_Z
 - GYRO_LPF_TF
@@ -220,6 +221,51 @@ enum
 
 #define VOLTAGE_FACTOR 850.0f
 
+#elif defined(ENV_HOVERSERVOGYRO_ESP32C3_WROOM_V1) // LSM6DS3, met achteruit (Marinedagen 2025)
+
+#define USE_CONFIG_HOVERSERVO
+
+// #define DEBUG_SERIAL Serial
+
+#define USE_FASTIMU
+#define FASTIMU_TYPE LSM6DS3
+#define IMU_I2C_ADDRESS 0x6B
+#define GYRO_DIRECTION GYRO_DIRECTION_X
+//#define GYRO_FLIP
+#define GYRO_REGELING_P         4.0
+#define GYRO_REGELING_MAX_DRAAI 1.0
+#define GYRO_REGELING_BIAS      1.0
+// #define SERVO_ANTI_BIBBER       3.0
+#define GYRO_LPF_TF             0.100 // Tf in seconds
+
+#define PIN_SERVO          10
+#define PIN_MOTOR          7
+#define PIN_MOTOR2         4
+
+#define PIN_LEDCONNECTIE   8
+#define PIN_LED_DUALUSE
+#define PIN_SDA            2          
+#define PIN_SCL            6
+
+#define PIN_BATMONITOR     1
+
+#define MOTORZ_TIME_UP 2000 // ms om motor naar vol vermogen te brengen
+
+#define LED_BRIGHTNESS_ON  LOW
+#define LED_BRIGHTNESS_OFF HIGH
+
+//#define USE_WS2812FX
+#define PIN_WS2812FX       8
+#define WS2812FX_NUMLEDS    6
+#define WS2812FX_RGB_ORDER  NEO_BGR //voor "fairy" type
+#define WS2812FX_BRIGHTNESS 255 // 0 .. 255
+#define WS2812FX_SPEED 1000 // in ms
+#define WS2812FX_COLOR 0x007BFF // blauw, 0x007BFF geeft violet en blauw met 0xFF0000 op fairy type met NEO_GRB?
+#define WS2812FX_MODE FX_MODE_FADE // FX_MODE_BLINK, ... Volledige lijst op https://github.com/kitesurfer1404/WS2812FX/blob/master/src/modes_arduino.h
+
+#define VOLTAGE_FACTOR 850.0f
+
+
 #elif defined ENV_USER_DEFINED
 // defines staan buiten de code
 
@@ -236,4 +282,5 @@ enum
 
 #endif
 #endif
+
 

--- a/ESP_Hover_Browser/config.h
+++ b/ESP_Hover_Browser/config.h
@@ -223,7 +223,7 @@ enum
 
 #elif defined(ENV_HOVERSERVOGYRO_ESP32C3_WROOM_V1) // LSM6DS3, met achteruit (Marinedagen 2025)
 
-#define USE_CONFIG_HOVERSERVO
+#define USE_CONFIG_HOVERSERVO_HBRIDGE
 
 // #define DEBUG_SERIAL Serial
 
@@ -239,8 +239,8 @@ enum
 #define GYRO_LPF_TF             0.100 // Tf in seconds
 
 #define PIN_SERVO          10
-#define PIN_MOTOR          7
-#define PIN_MOTOR2         4
+#define PIN_1ZMOTOR         7
+#define PIN_2ZMOTOR         4
 
 #define PIN_LEDCONNECTIE   8
 #define PIN_LED_DUALUSE
@@ -250,6 +250,7 @@ enum
 #define PIN_BATMONITOR     1
 
 #define MOTORZ_TIME_UP 2000 // ms om motor naar vol vermogen te brengen
+#define MOTORZ_MINSPEED 5
 
 #define LED_BRIGHTNESS_ON  LOW
 #define LED_BRIGHTNESS_OFF HIGH
@@ -280,7 +281,12 @@ enum
 
 #define WIFI_SOFTAP_SSID_PREFIX "hover-"
 
+#elif defined(USE_CONFIG_HOVERSERVO_HBRIDGE)
+
+#define WIFI_SOFTAP_SSID_PREFIX "hover-"
+
 #endif
 #endif
+
 
 

--- a/ESP_Hover_Browser/config.h
+++ b/ESP_Hover_Browser/config.h
@@ -280,6 +280,7 @@ enum
 #if defined(USE_CONFIG_HOVERSERVO)
 
 #define WIFI_SOFTAP_SSID_PREFIX "hover-"
+#define ZMOTOR_UP_ONLY
 
 #elif defined(USE_CONFIG_HOVERSERVO_HBRIDGE)
 
@@ -287,6 +288,7 @@ enum
 
 #endif
 #endif
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Video: https://www.youtube.com/watch?v=TWfIe7EutRM
 
 ## Communicatie
 - WifiPoint / SoftAP
-- SSID = hover- + 4 laatste hexadecimale karakters van het Wifi-MAC adres van de ESP8266 chip
+- SSID = hover- + 4 laatste hexadecimale karakters van het Wifi-MAC adres van de ESP-chip
 - Wifi-paswoord: 12345678
 - App: browser (Chrome, Firefox, safari, ...)
 - URL : http://192.168.4.1 of http://h.be

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Video: https://www.youtube.com/watch?v=TWfIe7EutRM
 - Bovenste regel: connectiestatus, en optioneel het voltage tijdens connectie (en optioneel de gyro draaisnelheid)
 - Bovenste slider: trim de servo
 - Tweede slider: stel maximum snelheid in (links = halve kracht, rechts=volle kracht)
-- Joystick: besturing servo (links-rechts) en motor (midden-boven)
+- Joystick: besturing servo (links-rechts) en motor (enkel midden-boven bij unidirectionele landhovercraft)
 
 ## pinallocatie Wemos D1 Lite (ESP8266)
 Hiertoe moet je volgende regel uncommenten in config.h:

--- a/README.md
+++ b/README.md
@@ -91,8 +91,14 @@ ESP32:
 - ArduinoWebsockets by Gil Maimon, gemakkelijk te installeren vanuit de Arduino Library manager: https://github.com/gilmaimon/ArduinoWebsockets
 - https://github.com/me-no-dev/ESPAsyncWebServer
 
-Daarnaast in geval van gyro GY-521:
-- https://github.com/LiquidCGS/FastIMU
+ESP32C3:
+- AsyncTCP: te installeren van https://github.com/me-no-dev/AsyncTCP
+- ESP32Servo vanuit de Arduino library manager te downloaden, dat is deze versie:  https://github.com/madhephaestus/ESP32Servo
+- ArduinoWebsockets by Gil Maimon, gemakkelijk te installeren vanuit de Arduino Library manager: https://github.com/gilmaimon/ArduinoWebsockets
+- https://github.com/dvarrel/ESPAsyncWebSrv versie 1.2.9
+
+Daarnaast in geval van gyro GY-521 of LSM6DS3TR-C
+- https://github.com/LiquidCGS/FastIMU, versie 1.2.8
 
 ## Inspiratie
 Bij het ontwikkelen van deze software werden volgende inspiratie-bronnen gebruikt: 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Video: https://www.youtube.com/watch?v=TWfIe7EutRM
 
 ## App User interface 
 ![Screenshot_browser_hovercraft.png](Screenshot_browser_hovercraft.png "Hover user interface")
-- Bovenste regel: connectiestatus, en op ESP8266 het voltage tijdens connectie (en optioneel de gyro draaisnelheid)
+- Bovenste regel: connectiestatus, en optioneel het voltage tijdens connectie (en optioneel de gyro draaisnelheid)
 - Bovenste slider: trim de servo
 - Tweede slider: stel maximum snelheid in (links = halve kracht, rechts=volle kracht)
 - Joystick: besturing servo (links-rechts) en motor (midden-boven)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Wifi-Hovercraft-Browser
-Wifi bestuurde (vanuit een browser ) hovercraft op een ESP8266 (NodeMCU, Wemos D1 mini) of ESP32 en een optionele gyro GY-521
+Wifi bestuurde (vanuit een browser ) hovercraft op een ESP8266 (NodeMCU, Wemos D1 mini) of ESP32/ESP32C3 en een optionele gyro GY-521 of LSM6DS3TR-C
 
 Video: https://www.youtube.com/watch?v=TWfIe7EutRM
 


### PR DESCRIPTION
Support for hovercraft (water version) as used on Marinedays 2025: it has 1 servo and 1 bidirectional motor

Hardware: custom PCB with ESP32C3, IMU LSM6DS3, servo, hbridge for 1 bidirectional motor

